### PR TITLE
LT募集ボタンの視認性向上

### DIFF
--- a/src/components/sections/Timetable.tsx
+++ b/src/components/sections/Timetable.tsx
@@ -42,6 +42,7 @@ export const Timetable = () => {
         <Button 
           asChild
           size="lg"
+          variant={null}
           className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-6 px-8 rounded-lg text-lg transition-colors"
         >
           <a 


### PR DESCRIPTION
ボタンの色とテキストの色が共に白色になっており、視認性に乏しいです。
これは利用しているButtonのvariantがdefaultで使用され、`bg-white` が先勝ちでstyleにあたってしまっているためです。

そのため、Buttonに明示的にstylingしていることを考慮し、variantにnullを指定して、classNameで使用しているstyleを優先させました。

Before
![スクリーンショット 2025-06-06 23 46 02](https://github.com/user-attachments/assets/ba579ca2-a8a2-40a8-ad97-0f0a523434cd)

After
![スクリーンショット 2025-06-06 23 55 01](https://github.com/user-attachments/assets/04aaca12-42d1-4d09-b6ae-b0a9a7ca8359)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of a button in the timetable section by explicitly setting its variant to none.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->