### PR TITLE
タイムテーブルを更新: 新しいスケジュールと未定セッションをComing Soonに設定

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -2,17 +2,13 @@ import React from 'react';
 import { Calendar, Clock } from 'lucide-react';
 import { Button } from '../ui/button';
 import { eventData } from '../../data/eventData';
-import { toast } from 'sonner';
 
 /**
  * ヒーローセクション
  */
 export const HeroSection = () => {
   const handleRegistrationClick = () => {
-    toast("現在準備中です", {
-      description: "参加申込みの詳細については、近日中にお知らせいたします。",
-      duration: 4000,
-    });
+    window.open('https://aiau.connpass.com/event/357272/', '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/src/components/sections/RegisterSection.tsx
+++ b/src/components/sections/RegisterSection.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 
 import { Button } from '../ui/button';
-import { toast } from 'sonner';
 
 /**
  * 参加申込みセクション
  */
 export const RegisterSection = () => {
   const handleRegistrationClick = () => {
-    toast("現在準備中です", {
-      description: "参加申込みの詳細については、近日中にお知らせいたします。",
-      duration: 4000,
-    });
+    window.open('https://aiau.connpass.com/event/357272/', '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/src/data/eventData.ts
+++ b/src/data/eventData.ts
@@ -10,16 +10,18 @@ export const eventData = {
   fee: "無料",
   description: "GitHub Copilotを活用したAIペアプログラミングの実践的な知見を共有するコミュニティイベントです。初心者から上級者まで、AIツールを活用したソフトウェア開発に興味のある方々が集まり、最新のテクニックや経験を交換します。",
   agenda: [
-    { time: "18:30-19:00", duration: "30分", title: "入場開始", speaker: "" },
-    { time: "19:00-19:15", duration: "15分", title: "会場案内・タイムテーブル発表", speaker: "" },
-    { time: "19:15-19:30", duration: "15分", title: "", speaker: "AI駆動開発勉強会 LINEヤフー 河本" },
-    { time: "19:35-19:45", duration: "10分", title: "LT募集中", speaker: "" },
-    { time: "19:50-20:00", duration: "10分", title: "LT募集中", speaker: "" },
-    { time: "20:05-20:20", duration: "15分", title: "VS CodeとGitHub Copilotで爆速開発！ アップデートの波に乗るおさらい会", speaker: "VS Code Meetup yamachu" },
-    { time: "20:25-20:40", duration: "15分", title: "", speaker: "Shotaro Suzuki, FPT Japan" },
-    { time: "20:45-21:00", duration: "15分", title: "", speaker: "サイボウズ" },
+    { time: "18:00-18:30", duration: "30分", title: "入場開始", speaker: "" },
+    { time: "18:30-18:40", duration: "10分", title: "会場案内・タイムテーブル発表", speaker: "" },
+    { time: "18:45-19:00", duration: "15分", title: "Coming Soon", speaker: "AIエージェントユーザー会 taiga" },
+    { time: "19:05-19:20", duration: "15分", title: "Coming Soon", speaker: "AI駆動開発勉強会 LINEヤフー 河本" },
+    { time: "19:25-19:35", duration: "10分", title: "LT募集中 (1)", speaker: "" },
+    { time: "19:40-19:50", duration: "10分", title: "LT募集中 (2)", speaker: "" },
+    { time: "19:50-20:00", duration: "10分", title: "休憩", speaker: "" },
+    { time: "20:00-20:15", duration: "15分", title: "VS CodeとGitHub Copilotで爆速開発！ アップデートの波に乗るおさらい会", speaker: "VS Code Meetup yamachu" },
+    { time: "20:20-20:35", duration: "15分", title: "Coming Soon", speaker: "Shotaro Suzuki, FPT Japan" },
+    { time: "20:40-20:55", duration: "15分", title: "Coming Soon", speaker: "サイボウズ" },
     { time: "21:00-21:45", duration: "45分", title: "OST", speaker: "" },
-    { time: "22:15-22:30", duration: "15分", title: "撤収作業", speaker: "" }
+    { time: "21:45-22:00", duration: "15分", title: "撤収作業・閉場", speaker: "" }
   ],
   speakers: []
 };


### PR DESCRIPTION
This pull request updates the event registration behavior and modifies the event agenda to reflect the latest schedule. The most important changes include replacing the toast notification with a link to the registration page and updating the event timeline in the `eventData` file.

### Registration Behavior Updates:
* Replaced the toast notification with a `window.open` call to redirect users to the event registration page (`https://aiau.connpass.com/event/357272/`) in the `HeroSection` and `RegisterSection` components. (`src/components/sections/HeroSection.tsx`: [[1]](diffhunk://#diff-b200e46af80aad586717f2469205917b3a8a2c6d4d146edbf61d3d8415158125L5-R11) `src/components/sections/RegisterSection.tsx`: [[2]](diffhunk://#diff-5bdf6858aa7c0e76e3eb3eb655f7a4dc05b78a73448a455378be51af25da9997L4-R10)

### Event Agenda Updates:
* Updated the `eventData` file to revise the event agenda, including changes to session times, titles, and speakers, as well as adjustments to the schedule for entry, breaks, and closing. (`src/data/eventData.ts`: [src/data/eventData.tsL13-R24](diffhunk://#diff-50bd7493c2bed5698bc27ea74391825f2220c045166c821709768b44eb125c51L13-R24))